### PR TITLE
Adding using namespace for ember kernel

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -7,37 +7,43 @@
 #include <keyboard.hpp>
 #include <serial.hpp>
 
+using namespace keyboard;
+using namespace serial;
+using namespace terminal;
+using namespace timer;
+using namespace vga;
+
 extern "C" void kernel_main(void)
 {
-  serial::init();
-  serial::log("knl", "Initializing");
-  serial::log("dts", "Initializing");
+  init();
+  log("knl", "Initializing");
+  log("dts", "Initializing");
   init_descriptor_tables();
   asm volatile ("sti");
-  serial::log("tty", "Initializing");
-  terminal::initialize();
+  log("tty", "Initializing");
+  initialize();
 
   // Ember logo
-  terminal::setcolor(VGA_COLOR_LIGHT_BROWN, VGA_COLOR_BLACK);
-  terminal::print("   __ _ _ __ _   _ ___ \n"
+  setcolor(VGA_COLOR_LIGHT_BROWN, VGA_COLOR_BLACK);
+  print("   __ _ _ __ _   _ ___ \n"
                   "  / _` | '__| | | / __|\n"
                   " | (_| | |  | |_| \\__ \\ \n"
                   "  \\__,_|_|   \\__,_|___/ \n");
 
-  terminal::setcolor(VGA_COLOR_WHITE, VGA_COLOR_BLACK);
-  terminal::print("Welcome to Arus!\n");
-  terminal::print("Version 1, Build 0.0.1\n");
-  serial::log("pit", "Initializing");
-  timer::init(100);
-  serial::log("kbd", "Initializing");
-  keyboard::init();
-  serial::log("knl", "Initialized");
-  terminal::print("> ");
+  setcolor(VGA_COLOR_WHITE, VGA_COLOR_BLACK);
+  print("Welcome to Arus!\n");
+  print("Version 1, Build 0.0.1\n");
+  log("pit", "Initializing");
+  init(100);
+  log("kbd", "Initializing");
+  init();
+  log("knl", "Initialized");
+  print("> ");
   char theinput[25];
-  keyboard::input(24, theinput);
-  terminal::print("You said this: ");
-  terminal::print(theinput);
-  terminal::print("\nTest interrupt:\n");
+  input(24, theinput);
+  print("You said this: ");
+  print(theinput);
+  print("\nTest interrupt:\n");
   asm volatile ("int $0x13");
   for (;;){
     asm volatile("hlt");

--- a/src/lib/dt.cpp
+++ b/src/lib/dt.cpp
@@ -4,6 +4,10 @@
 #include <isr.hpp>
 #include <serial.hpp>
 
+using namespace serial;
+using namespace gdt;
+using namespace idt;
+
 extern "C" void gdt_flush(uint32_t);
 extern "C" void idt_flush(uint32_t);
 
@@ -37,7 +41,7 @@ static void init_gdt() {
   gdt_set_gate(6, 0, 0xFFFFFFFF, 0xF6, 0xCF); // User mode stack segment
 
   gdt_flush((uint32_t)&gdt_ptr);
-  serial::log("gdt", "Initialized");
+  log("gdt", "Initialized");
 }
 } // namespace gdt
 
@@ -125,15 +129,15 @@ static void init_idt()
     idt_set_gate(47, (uint32_t)irq15, 0x08, 0x8E);
 
     idt_flush((uint32_t)&idt_ptr);
-    serial::log("gdt", "Initialized");
+    log("gdt", "Initialized");
 }
 } // namespace idt
 
 void init_descriptor_tables()
 {
-  serial::log("gdt", "Initializing");
-  gdt::init_gdt();
-  serial::log("idt", "Initializing");
-  idt::init_idt();
-  serial::log("dts", "Initialized");
+  log("gdt", "Initializing");
+  init_gdt();
+  log("idt", "Initializing");
+  init_idt();
+  log("dts", "Initialized");
 }

--- a/src/lib/isr.cpp
+++ b/src/lib/isr.cpp
@@ -2,17 +2,19 @@
 #include <isr.hpp>
 #include <io.hpp>
 
+using namespace terminal;
+
 isr_t interrupt_handlers[256];
 
 extern "C" void isr_handler(registers_t regs)
 {
-  terminal::print("recieved interrupt: ");
-  terminal::print_hex(regs.int_no);
+  print("recieved interrupt: ");
+  print_hex(regs.int_no);
   if (regs.err_code != 0) {
-    terminal::print(", errno: ");
-    terminal::print_hex(regs.err_code);
+    print(", errno: ");
+    print_hex(regs.err_code);
   }
-  terminal::print("\n");
+  print("\n");
   asm volatile ("cli");
 }
 

--- a/src/lib/keyboard.cpp
+++ b/src/lib/keyboard.cpp
@@ -5,6 +5,9 @@
 #include <serial.hpp>
 #include <stdbool.h>
 
+using namespace terminal;
+using namespace serial;
+
 namespace keyboard
 {
 bool ginput = false;
@@ -61,7 +64,7 @@ static void keyboard_handler(registers_t *regs)
 void init(void)
 {
    register_interrupt_handler(33, &keyboard_handler);
-   serial::log("kbd", "Initialized");
+   log("kbd", "Initialized");
 }
 
 char getchar()
@@ -85,12 +88,12 @@ void input(unsigned int input_length, char *theinput)
             if (position != 0) {
                 theinput[position] = 0;
                 position--;
-                terminal::putchar(character);
+                putchar(character);
             }
         } else if (position != last_position) {
             if (character != '\n') theinput[position] = character;
             position++;
-            terminal::putchar(character);
+            putchar(character);
         }
     }
 }

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -6,6 +6,9 @@
 #include <terminal.hpp>
 #include <serial.hpp>
 
+using namespace serial;
+using namespace vga;
+
 namespace terminal {
 static const size_t VGA_WIDTH = 80;
 static const size_t VGA_HEIGHT = 25;
@@ -23,15 +26,15 @@ uint16_t *buffer;
 void initialize(void) {
   row = 0;
   column = 0;
-  color = vga::vga_entry_color(VGA_COLOR_WHITE, VGA_COLOR_BLACK);
+  color = vga_entry_color(VGA_COLOR_WHITE, VGA_COLOR_BLACK);
   buffer = (uint16_t *)0xB8000;
   for (size_t y = 0; y < VGA_HEIGHT; y++) {
     for (size_t x = 0; x < VGA_WIDTH; x++) {
       const size_t index = y * VGA_WIDTH + x;
-      buffer[index] = vga::vga_entry(' ', color);
+      buffer[index] = vga_entry(' ', color);
     }
   }
-  serial::log("tty", "Initialized");
+  log("tty", "Initialized");
 }
 
 void setcolor(enum vga_color fore, enum vga_color back) {
@@ -42,7 +45,7 @@ void setcolor(enum vga_color fore, enum vga_color back) {
 
 void putentryat(char c, uint8_t color, size_t x, size_t y) {
   const size_t index = y * VGA_WIDTH + x;
-  buffer[index] = vga::vga_entry(c, color);
+  buffer[index] = vga_entry(c, color);
 }
 
 // Updates the hardware cursor.

--- a/src/lib/timer.cpp
+++ b/src/lib/timer.cpp
@@ -5,6 +5,8 @@
 #include <io.hpp>
 #include <serial.hpp>
 
+using namespace serial;
+
 namespace timer
 {
 uint32_t tick = 0;
@@ -35,6 +37,6 @@ void init(uint32_t frequency)
    // Send the frequency divisor.
    outb(0x40, l);
    outb(0x40, h);
-   serial::log("pit", "Initialized");
+   log("pit", "Initialized");
 }
 } // namespace timer


### PR DESCRIPTION
Ember adds the namespaces used for the kernel and removes unnecessary code, e.g. "std::print("");" instead of "print("");" is used. Namespaces used for all files have been added. @ardatdev @Arnolxu

* I started CPP and this place came to my mind and I wanted to make a small contribution.